### PR TITLE
Ignore undocumented attribute writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
   # documentation coverage is not influenced by ruby implementation, so only run once
   include:
     - rvm: 2.1
-      env: RAKE_TASK=yard
+      env: RAKE_TASK=yard:stats
 rvm:
   - '2.1'
   # jruby fails rake cucumber (see MSP-11240)

--- a/lib/metasploit/yard.rb
+++ b/lib/metasploit/yard.rb
@@ -11,6 +11,7 @@ require 'metasploit/yard/version'
 module Metasploit
   # Namespace for this gem.
   module Yard
+    autoload :CLI, 'metasploit/yard/cli'
     autoload :Aruba, 'metasploit/yard/aruba'
 
     if defined?(Rails)

--- a/lib/metasploit/yard/cli.rb
+++ b/lib/metasploit/yard/cli.rb
@@ -1,0 +1,4 @@
+# Namespace for overrides of `YARD::CLI` namespace classes.
+module Metasploit::Yard::CLI
+  autoload :Stats, 'metasploit/yard/cli/stats'
+end

--- a/lib/metasploit/yard/cli/stats.rb
+++ b/lib/metasploit/yard/cli/stats.rb
@@ -1,0 +1,13 @@
+# Extends `YARD::CLI::Stats` to not mark writers as undocuments for instance attributes.
+class Metasploit::Yard::CLI::Stats < ::YARD::CLI::Stats
+  # Statistics for methods
+  def stats_for_methods
+    objs = all_objects.select {|m| m.type == :method }
+    objs.reject! {|m| m.is_alias? }
+    undoc = objs.select { |m|
+      m.docstring.blank? && !(m.writer? && m.is_attribute?)
+    }
+    @undoc_list |= undoc if @undoc_list
+    output "Methods", objs.size, undoc.size
+  end
+end

--- a/lib/metasploit/yard/version.rb
+++ b/lib/metasploit/yard/version.rb
@@ -7,8 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 0
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 2
+      PATCH = 3
       # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+      PRERELEASE = 'ignore-undocumented-attribute-writer'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the PRERELEASE in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/lib/tasks/yard.rake
+++ b/lib/tasks/yard.rake
@@ -23,7 +23,8 @@ namespace :yard do
 
   desc "Shows stats for YARD Documentation including listing undocumented modules, classes, constants, and methods"
   task :stats => :environment do
-    stats = YARD::CLI::Stats.new
+    require 'metasploit/yard'
+    stats = Metasploit::Yard::CLI::Stats.new
     stats.run('--compact', '--list-undoc')
 
     threshold = 100.0

--- a/lib/tasks/yard.rake
+++ b/lib/tasks/yard.rake
@@ -53,6 +53,10 @@ namespace :yard do
   end
 end
 
+task :environment do
+  # stub task for when not run in a Rails project
+end
+
 # @todo Figure out how to just clone description from yard:doc
 desc "Generate YARD documentation"
 # allow calling namespace to as a task that goes to default task for namespace


### PR DESCRIPTION
MSP-12718

Ignore undocumented attribute writers because attributes only need to have reader documentation when rendered as HTML.  See https://github.com/lsegal/yard/issues/862 for why yard:stats says the writer is undocumented, but why it's also ok to ignore it.

# Verification Steps

- [x] `bundle install`

## metasploit-yard
### `rake cucumber`
- [x] `rake cucumber`
- [ ] VERIFY no failures

### `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

## metasploit-cache
- [ ] Verify https://github.com/rapid7/metasploit-cache/pull/44 works with pre-release github ref of this PR.

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/metasploit/yard/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## MRI Ruby
- [ ] `rvm use ruby-2.1@metasploit-yard`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

# Post-release steps
- [ ] Update https://github.com/rapid7/metasploit-cache/pull/44 to use released metasploit-yard 1.0.3.
  - [ ] Change `spec.add_development_dependency 'metasploit-yard', '~> 1.0'` to `spec.add_development_dependency 'metasploit-yard', '>= 1.0.3', '< 2.0'` in `metasploit-cache.gemspec`
  - [ ] Remove from `Gemfile`: 
```

group :development do
  gem 'metasploit-yard', github: 'rapid7/metasploit-yard', ref: '3ca321c47cba178d298f347d6006995b28c76226'
end
```