### PR TITLE
convert specs with transpec

### DIFF
--- a/lib/metasploit/yard/version.rb
+++ b/lib/metasploit/yard/version.rb
@@ -7,7 +7,9 @@ module Metasploit
       # The minor version number, scoped to the {MAJOR} version number.
       MINOR = 0
       # The patch number, scoped to the {MINOR} version number.
-      PATCH = 3
+      PATCH = 2
+
+      PRERELEASE = 'transpec-conversion'
 
       # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the PRERELEASE in the
       # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/metasploit/yard/version_spec.rb
+++ b/spec/metasploit/yard/version_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Metasploit::Yard::Version do
       3
     end
 
-    before(:each) do
+    before(:example) do
       stub_const("#{described_class}::MAJOR", major)
       stub_const("#{described_class}::MINOR", minor)
       stub_const("#{described_class}::PATCH", patch)
@@ -121,7 +121,7 @@ RSpec.describe Metasploit::Yard::Version do
         'prerelease'
       end
 
-      before(:each) do
+      before(:example) do
         stub_const("#{described_class}::PRERELEASE", prerelease)
       end
 
@@ -131,7 +131,7 @@ RSpec.describe Metasploit::Yard::Version do
     end
 
     context 'without PRERELEASE' do
-      before(:each) do
+      before(:example) do
         hide_const("#{described_class}::PRERELEASE")
       end
 


### PR DESCRIPTION
update all specs to latest rspec 3 syntax

MS-1086

# Verification Steps

- [x] `bundle install`

## `rake cucumber`
- [x] `rake cucumber`
- [x] VERIFY no failures

## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/metasploit/yard/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`