### PR TITLE
update to support rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ group: stable
 sudo: false
 language: ruby
 rvm:
-  - 2.3.2
+  - 2.6.5
 before_install:
-  - gem update bundler
+  - gem install bundler
 script:
   - bundle exec rake spec
   - bundle exec rake cucumber

--- a/lib/metasploit/yard/version.rb
+++ b/lib/metasploit/yard/version.rb
@@ -1,7 +1,7 @@
 module Metasploit
   module Yard
     # VERSION is managed by GemRelease
-    VERSION = '2.0.5'
+    VERSION = '3.0.0'
     
     # @return [String]
     #

--- a/metasploit-yard.gemspec
+++ b/metasploit-yard.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   # assert_valid_keys
-  spec.add_development_dependency 'activesupport', '~> 4.2.6'
+  spec.add_development_dependency 'activesupport', '~> 5.2.2'
   spec.add_development_dependency 'aruba'
   spec.add_development_dependency 'bundler'
   # spec.add_development_dependency 'codeclimate-test-reporter'


### PR DESCRIPTION
Updates dependencies to support Rails 5.2.

Due to compatibility options for Rails dependency this reflects a breaking change.

Set version to 3.0.0, open to input on version as 2.1.0 since no code changes.